### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-taskstowing-container/pom.xml
+++ b/worker-taskstowing-container/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice.workers.taskstowing</groupId>
     <artifactId>worker-taskstowing-container</artifactId>
+    <name>worker-taskstowing-container</name>
     <version>1.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 

--- a/worker-taskstowing/pom.xml
+++ b/worker-taskstowing/pom.xml
@@ -23,6 +23,7 @@
 
     <groupId>com.github.jobservice.workers.taskstowing</groupId>
     <artifactId>worker-taskstowing</artifactId>
+    <name>worker-taskstowing</name>
     <version>1.0.0-SNAPSHOT</version>
 
     <parent>


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210